### PR TITLE
Deterministic sort for bundles with same id

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,16 +2,16 @@ var through = require('through');
 
 module.exports = function (opts) {
     if (!opts) opts = {};
-    
+
     var rows = [];
     return through(write, end);
-    
+
     function write (row) { rows.push(row) }
-    
+
     function end () {
         var tr = this;
         rows.sort(cmp);
-        
+
         if (opts.index) {
             var index = {};
             rows.forEach(function (row, ix) {
@@ -33,8 +33,8 @@ module.exports = function (opts) {
         }
         tr.queue(null);
     }
-    
+
     function cmp (a, b) {
-        return a.id < b.id ? -1 : 1;
+        return a.id + a.hash < b.id + b.hash ? -1 : 1;
     }
 };


### PR DESCRIPTION
Fixes https://github.com/substack/node-browserify/issues/711

Bundles with the same id were being kept in the same order that they were passed in, which was non-deterministic, thus the output was also non-deterministic.  This fixes that.
