### PR TITLE
Fix calling Object.keys on undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ function depCmp (hashes) {
         hashes[row.id] = hash;
     }
     function cmp (a, b, limit) {
+        if(!a || !b) {
+            return false;
+        }
+        
         var keys = Object.keys(a);
         if (keys.length !== Object.keys(b).length) return false;
 


### PR DESCRIPTION
I am not sure why browserify 5 is even running into this issue, but I can't bundle my app anymore without this fix.

Any insight as to why `a` or `b` might be undefined?
