### PR TITLE
ci: add versions that browserify supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "12"
+  - "10"
+  - "9"
+  - "8"
+  - "6"
+  - "4"
+  - "iojs"
   - "0.12"
-  - node
+  - "0.10"
+  - "0.8"
+before_install:
+  # Old npm certs are untrusted https://github.com/npm/npm/issues/20191
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.8" ]; then export NPM_CONFIG_STRICT_SSL=false; fi'
+  - 'nvm install-latest-npm'


### PR DESCRIPTION
making sure that we don't accidentally break Node.js 0.8 in the future.