### PR TITLE
Remove shasum dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 var through = require('through2');
-var shasum = require('shasum');
+var crypto = require('crypto');
+
+function shasum (text) {
+    return crypto.createHash('sha1').update(text).digest('hex');
+}
 
 module.exports = function (opts) {
     if (!opts) opts = {};

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ var through = require('through2');
 var crypto = require('crypto');
 
 function shasum (text) {
-    return crypto.createHash('sha1').update(text).digest('hex');
+    return crypto.createHash('sha1')
+        .update(text, Buffer.isBuffer(text) ? null : 'utf8')
+        .digest('hex');
 }
 
 module.exports = function (opts) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "shasum": "^1.0.0",
     "subarg": "^1.0.0",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
shasum uses json-stable-stringify, which pulls in some very old dependencies. deps-sort never actually enters that code path so we can just implement the function manually and save some install time and license warnings.